### PR TITLE
refactor: tidy up common and unused properties of fiducial marker detector classes

### DIFF
--- a/cares_lib/vision/ArucoDetector.py
+++ b/cares_lib/vision/ArucoDetector.py
@@ -3,9 +3,9 @@ from cares_lib.vision.MarkerDetector import MarkerDetector
 
 class ArucoDetector(MarkerDetector):
     def __init__(self, marker_size, dictionary_id=cv2.aruco.DICT_4X4_50):
+        super().__init__(marker_size)
         self.dictionary = cv2.aruco.Dictionary_get(dictionary_id)
         self.aruco_params = cv2.aruco.DetectorParameters_create()
-        self.marker_size = marker_size
 
     def get_marker_poses(self, image, camera_matrix, camera_distortion, display=True):
         (corners, ids, rejected_points) = cv2.aruco.detectMarkers(

--- a/cares_lib/vision/MarkerDetector.py
+++ b/cares_lib/vision/MarkerDetector.py
@@ -5,9 +5,7 @@ from abc import ABC
 
 class MarkerDetector(ABC):
     """Base class for marker detectors like ArucoDetector and STagDetector"""
-    def __init__(self, marker_size, dictionary_id=cv2.aruco.DICT_4X4_50):
-        self.dictionary = cv2.aruco.Dictionary_get(dictionary_id)
-        self.aruco_params = cv2.aruco.DetectorParameters_create()
+    def __init__(self, marker_size):
         self.marker_size = marker_size
 
     def get_orientation(self, r_vec):

--- a/cares_lib/vision/STagDetector.py
+++ b/cares_lib/vision/STagDetector.py
@@ -10,9 +10,9 @@ class STagDetector(MarkerDetector):
             Value needs to be in range 0 \<= error_correction \<= (HD-1)/2.
             If set to -1, the max possible value for the given library HD is used.
         """
+        super().__init__(marker_size)
         self.dictionary = library_hd
         self.error_correction = error_correction
-        self.marker_size = marker_size
 
     def get_marker_poses(self, image, camera_matrix, camera_distortion, display=True):
         (corners, ids, rejected_points) = stag.detectMarkers(image, self.dictionary, self.error_correction)


### PR DESCRIPTION
Use property "marker_size" of MarkerDetector base class and removed unused properties "dictionary" and "aruco_params" of MarkerDetector base class